### PR TITLE
fix: add optional chain for post image

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -56,7 +56,7 @@ const Home: React.FC<{ data: AllMarkdownRemark }> = ({ data }) => {
               title={post.frontmatter.title}
               date={post.frontmatter.date}
               timeToRead={post.timeToRead}
-              image={post.frontmatter.image.childImageSharp.fluid}
+              image={post.frontmatter.image?.childImageSharp?.fluid}
               slug={post.fields.localizedSlug}
             />
           );


### PR DESCRIPTION
It avoids breaking the entire rendering when the imagine is not found